### PR TITLE
Added arch linux as a supported distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Any linux distribution with the necessary [dependencies](#dependencies) is suppo
    - impish
    - focal
    - bionic
+- Arch
 
 Distribution
 ------------


### PR DESCRIPTION
Since an AUR package exists for oip now, it should be listed as a supported distribution. It can be found here: https://aur.archlinux.org/packages/oip. Though, since it builds from source, it is technically not pre-built. I am open to suggestions